### PR TITLE
add issue templates

### DIFF
--- a/.github/bug_report.md
+++ b/.github/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Describe the bug
+A clear and concise description of what the bug is.
+
+### To Reproduce
+Steps to reproduce the behavior:
+
+1. Step 1
+2. Step 2
+3. ...
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+### System
+
+- OS: [e.g. MacOS 10.14.3]
+- Terminal: [e.g. iTerm, PowerShell]
+- Node version: `node -v`
+
+### Additional context
+Add any other context about the problem here.

--- a/.github/bug_report.md
+++ b/.github/bug_report.md
@@ -21,9 +21,7 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 ### System
-
 - OS: [e.g. MacOS 10.14.3]
-- Terminal: [e.g. iTerm, PowerShell]
 - Node version: `node -v`
 
 ### Additional context

--- a/.github/feature_request.md
+++ b/.github/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Is your feature request related to a problem?
+Please describe. A clear and concise description of what the problem is.
+Ex. I'm always frustrated when [...]
+
+### Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+### Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+### Additional context
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
**What is the change?**
- Add issue templates

**Why are we making this change?**
- By adding [issue templates](https://help.github.com/en/articles/creating-issue-templates-for-your-repository) (a native github feature), we can prompt contributors to answer a few questions before submitting an issue.

When a user clicks `new issue` they will be prompted to choose which type of issue it is:
![Screen Shot 2019-08-13 at 11 55 35 PM](https://user-images.githubusercontent.com/6743796/63000398-e796d500-be25-11e9-9f17-df8fccfdec4c.png)

After choosing the type of issue, they will be shown a template inside the issues text area editor:

![Screen Shot 2019-08-13 at 11 56 54 PM](https://user-images.githubusercontent.com/6743796/63000485-2462cc00-be26-11e9-8103-107cb02b5796.png)




